### PR TITLE
a readline app with replic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+LISP?=sbcl
+
+build:
+	$(LISP)	--non-interactive \
+		--load lyrics.asd \
+		--eval '(ql:quickload :lyrics)' \
+		--eval '(asdf:make :lyrics)'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # lyrics
+
 Search song lyrics or, the other way around, search songs from lyrics.
+
+Available as a CL library and as a terminal application.
+
 
 # Installation
 
@@ -17,6 +21,16 @@ git clone https://github.com/mihaiolteanu/lyrics ~/quicklisp/local-projects/lyri
 # A sqlite3 database is used to store the lyrics
 sudo pacman -S sqlite3 
 ```
+
+Optionally, build the terminal app:
+
+```bash
+make build
+```
+
+This produces a `lyrics` binary with the two commands `lyrics` and
+`search-song` available.
+
 
 # Usage
 
@@ -83,6 +97,10 @@ The following lyrics websites are currently supported and searched for lyrics:
 If the song cannot be found on any of the websites, `lyrics` returns nil. Otherwise
 `lyrics` returns the song lyrics and saves them in the database from where they
 will be fetched on the next call. The `lyrics` function is memoized.
+
+The readline application is built quite automatically with the
+[replic](https://github.com/vindarel/replic/) library.
+
 
 ## Authors
 Copyright (c) 2019 [Mihai Olteanu](www.mihaiolteanu.me)

--- a/lyrics.asd
+++ b/lyrics.asd
@@ -12,7 +12,13 @@
                :sqlite
                :alexandria
                :bordeaux-threads
-               :defmemo)
+               :defmemo
+               :replic)
   :serial t
+
+  :build-operation "program-op"
+  :build-pathname "lyrics"
+  :entry-point "lyrics::main"
+
   :components ((:file "package")
                (:file "lyrics")))


### PR DESCRIPTION
Hello,

This is a PR that brings lyrics as a readline application, which I did mainly as a crash test for my library replic (https://github.com/vindarel/replic/) (but also because I want to use `lyrics` on the terminal!). `replic`'s goal is to allow to transform a lisp library into a readline application straight away. After two upstream commits, I can say it fulfills its goal :) The core of the change is this:

```
  (replic.completion:functions-to-commands :lyrics) ;; => transform the exported symbols into commands
  (replic:autoprint-results-from :lyrics)  ;; => we print what they return
```

So, we get:
- a prompt with `replic` built-ins (help system, ability to read a config file, history, catching a `C-c` and a `C-d`,…)
- two commands: lyrics and search-song (and we can TAB-complete the name).

The binary doesn't parse CLI args. That could be a nice addition.

If you are not interested, that's ok :]

ps: you need a recent QL version, less than a month old, for a compatible `replic` version.